### PR TITLE
Fix failing React test

### DIFF
--- a/frontend/src/App.test.js
+++ b/frontend/src/App.test.js
@@ -1,8 +1,16 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
+import RTCProvider from './context/RTCPeerContext';
+import SocketProvider from './context/SocketContext';
 
-test('renders learn react link', () => {
-  render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+test('renders Project Lightspeed header', () => {
+  render(
+    <RTCProvider>
+      <SocketProvider>
+        <App />
+      </SocketProvider>
+    </RTCProvider>
+  );
+  const headers = screen.getAllByText(/Project Lightspeed/i);
+  expect(headers.length).toBeGreaterThan(0);
 });

--- a/frontend/src/setupTests.js
+++ b/frontend/src/setupTests.js
@@ -3,3 +3,34 @@
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
 import '@testing-library/jest-dom';
+
+// Provide a basic MediaStream stub for tests
+global.MediaStream = class {
+  addTrack() {}
+};
+
+// Stub RTCPeerConnection for tests
+global.RTCPeerConnection = class {
+  addIceCandidate() {}
+  createAnswer() { return {}; }
+  setLocalDescription() {}
+  setRemoteDescription() {}
+  addEventListener() {}
+};
+
+// Simple WebSocket mock
+global.WebSocket = class {
+  constructor(url) {
+    this.url = url;
+    this.readyState = 1; // OPEN
+  }
+  send() {}
+  close() { this.readyState = 3; }
+  addEventListener() {}
+  removeEventListener() {}
+};
+
+// Mock fetch used by SocketProvider
+global.fetch = jest.fn(() =>
+  Promise.resolve({ json: () => Promise.resolve({ wsUrl: 'ws://localhost' }) })
+);


### PR DESCRIPTION
## Summary
- patch `App.test.js` to use context providers and check for header text
- add Jest setup stubs for browser APIs needed during tests

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687c6dbc54cc8324b4a019c4dfa4fd08