### PR TITLE
Remove stream-key CLI option and unused key functions

### DIFF
--- a/ingest/README.md
+++ b/ingest/README.md
@@ -46,11 +46,7 @@
       </ul>
     </li>
     <li><a href="#usage">Usage</a></li>
-    <li><a href="#streaming-from-obs">Streaming From OBS</a>
-        <ul>
-            <li><a href="#stream-key">Stream Key</a></li>
-        </ul>  
-    </li>
+    <li><a href="#streaming-from-obs">Streaming From OBS</a></li>
     <li><a href="#roadmap">Roadmap</a></li>
     <li><a href="#contributing">Contributing</a></li>
     <li><a href="#license">License</a></li>
@@ -148,17 +144,7 @@ After restarting OBS you should be able to see your service in the OBS settings 
 (Special Thanks to [Glimesh](https://github.com/Glimesh) for these instructions)
 
 
-### Stream Key
-By default on first time startup a new stream key will be generated and output to the terminal for you. In order 
-to regenerate this key simply delete the file it generates called `hash`. Simply copy the key output in the terminal 
-to OBS and you are all set! This key WILL NOT change unless the `hash` file is deleted.
 
-You can assign a static key by passing `--stream-key mykey` or via environment variable `STREAM_KEY=mykey`. If you 
-assign it manually it will become prefixed with `77-` so the result will be `77-mykey`. You can verify this in the boot 
-logs.
-
-
-<img src="images/streamkey-example.png" alt="Streamkey example">
 
 <!-- ROADMAP -->
 

--- a/ingest/src/cli.yml
+++ b/ingest/src/cli.yml
@@ -11,13 +11,6 @@ args:
         help: Specify which address to bind to (defaults to 0.0.0.0)
         takes_value: true
 
-    - stream-key:
-        short: k
-        long: stream-key
-        env: STREAM_KEY
-        value_name: STREAM_KEY
-        help: Optionally set a static Stream Key (will be prefixed with "77-")
-        takes_value: true
     
     # Optional path to the log file, creates a simplelog::WriteLogger
     - log-file:


### PR DESCRIPTION
## Summary
- drop `stream-key` argument from CLI
- remove stream key documentation
- delete unused stream key helpers

## Testing
- `cargo check --quiet`

------
https://chatgpt.com/codex/tasks/task_e_687d3f6b6dd08324b8f9908188cd3f66