### PR TITLE
Update setup docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,6 @@
                 <li><a href="#lightspeed-react">Lightspeed React</a></li>
             </ul>
         </li>
-        <li><a href="#docker">Docker / Compose</a></li>
         <li><a href="#community-installation">Community Installation</a></li>
       </ul>
     </li>
@@ -85,7 +84,7 @@ your own web app, ingest server or broadcast server.
 
 ### How It Works
 
-Lightspeed Ingest listens on port 8084 which is the port used by the FTL protocol. Upon receiving a connection it completes the FTL handshake and negotiates a port (this is currently bugged however and defaults to 65535). Once the negotiation is done Lightspeed WebRTC listens on the negotiated port (in the future Lightspeed WebRTC will listen on the loopback interface so the ingest has more control on what packets we accept) and relays the incoming RTP packets over WebRTC. Lightspeed React communicates via websocket with Lightspeed WebRTC to exchange ICE Candidates and once a connection is established the video can be viewed.
+Lightspeed Ingest listens on port 8084 which is the port used by the FTL protocol. Upon receiving a connection it completes the FTL handshake and negotiates a port (this is currently bugged however and defaults to 65535). Once the negotiation is done Lightspeed WebRTC listens on the negotiated port (in the future Lightspeed WebRTC will listen on the loopback interface so the ingest has more control on what packets we accept) and relays the incoming RTP packets over WebRTC. Lightspeed React communicates via websocket with Lightspeed WebRTC to exchange ICE Candidates and once a connection is established the video can be viewed
 
 ### Diagram
 Here is a diagram that outlines the current implementation and the future implementation that I would like to achieve. The reason I want the packets relayed from Ingest to WebRTC on the loopback interface is so that we have more control over who can send packets. Meaning that when a DISCONNECT command is recieved we can terminate the UDP listener so that someone could not start sending packets that we do not want
@@ -112,55 +111,51 @@ We now have a [Discord](https://discord.gg/UpQZANPYmZ) server! This is a great w
 ## Getting Started
 
 In order to get a copy running you will need to install all 3 repositories. There are installation instructions in 
-each repo however I will include them here for the sake of simplicity.
+each repo however I will include them here for the sake of simplicity
 
 ### Prerequisites
 
-In order to run Lightspeed, [Golang](https://golang.org/doc/install), [Rust](https://www.rust-lang.org/tools/install), and [npm](https://www.npmjs.com/get-npm) are required. Additionally the Rust repo requires a C compiler. If you get a `linker cc not found` error then you need to install a C compiler.
+In order to run Lightspeed, [Golang](https://golang.org/doc/install),
+[Rust](https://www.rust-lang.org/tools/install), and
+[npm](https://www.npmjs.com/get-npm) are required. Additionally the Rust repo
+requires a C compiler. If you get a `linker cc not found` error then you need to
+install a C compiler
 
 ### Installation
 
-#### Clone Repository
+1. **Clone Repository**
 
-```sh
-git clone https://github.com/acarlton5/ITGv2
-```
+   ```sh
+   git clone https://github.com/acarlton5/ITGv2
+   cd ITGv2
+   ```
 
-#### Build Ingest Server
+2. **Build Ingest Server**
 
-```sh
-cd ingest
-cargo build
-```
+   ```sh
+   cd ingest
+   cargo build
+   cd .
+   ```
 
-#### Build WebRTC Server
+3. **Build WebRTC Server**
 
-Using go get
+   ```sh
+   cd webrtc
+   go build
+   cd .
+   ```
 
-**Warning: Deprecated method (relies on outdated repository)**
+4. **Build Frontend**
 
-```sh
-export GO111MODULE=on
-go get github.com/acarlton5/ITGv2
-```
-
-Using git
-
-```sh
-cd webrtc
-export GO111MODULE=on
-go build
-```
-
-#### Frontend (Based on React.JS)
-
-```sh
-cd frontend
-npm install
-```
+   ```sh
+   cd frontend
+   npm install
+   ```
 
 ### Community Installation (**Warning: Outdated. Uses deprecated repositories**)
-Some of our awesome community members have written their own installers for Lightspeed. Here are links to those!
+Some of our awesome community members have written their own installers for Lightspeed
+Here are links to those!
 
 **Note**: If you want to make a custom installer do so in the `/contrib` folder and submit a PR. Please make sure to include a README on how to use it!
 
@@ -179,14 +174,6 @@ cargo run --release
 
 #### Lightspeed WebRTC
 
-Using go get
-
-**Warning: Deprecated method (relies on outdated repository)**
-
-```sh
-lightspeed-webrtc --addr=XXX.XXX.XXX.XXX
-```
-
 Using git
 
 ```sh
@@ -200,7 +187,7 @@ go build
 |  Argument | Supported Values | Defaults | Notes             |
 | :-------- | :--------------- | :------- | :---------------- |
 | `--addr`   | A valid IP address | `localhost` | This is the local Ip address of your machine. It defaults to localhost but should be set to your local IP. For example 10.17.0.5 This is where the server will listen for UDP packets and where it will host the websocket endpoint for SDP negotiation|
-|  `--ip`    | A valid IP address | `none` | Sets the public IP address for WebRTC to use. This is especially useful in the context of Docker|
+|  `--ip`    | A valid IP address | `none` | Sets the public IP address for WebRTC to use. |
 | `--ports`  | A valid UDP port range | `20000-20500` | This sets the UDP ports that WebRTC will use to connect with the client |
 | `--ws-port` | A valid port number | `8080` | This is the port on which the websocket will be hosted. If you change this value make sure that is reflected in the URL used by the react client |
 | `--rtp-port` | A valid port number | `65535` | This is the port on which the WebRTC service will listen for RTP packets. Ensure this is the same port that Lightspeed Ingest is negotiating with the client |
@@ -209,7 +196,7 @@ go build
 #### Lightspeed React
 
 You should then configure the websocket URL in `config.json` in the `build` directory. If you are using an IP then it will be the 
-public IP of your machine if you have DNS then it will be your hostname.
+public IP of your machine if you have DNS then it will be your hostname
 
 **Note**: The websocket port is hardcoded meaning that Lightspeed-webrtc will always serve it on port 8080 (this may change in the future) 
 so for the websocket config it needs to be `ws://IP_or_Hostname:8080/websocket`
@@ -219,58 +206,14 @@ You can host the static site locally using `serve` which can be found [here](htt
 **Note**: your version of `serve` may require the `-p` flag instead of `-l` for the port
 ```sh
 cd frontend
+npm install
 npm run build
 serve -s build -l 80
 ```
 
-The above will serve the build folder on port 80.
+The above will serve the build folder on port 80
 
 View Lightspeed in your web browser by visiting http://hostname or http://your.ip.address.here
-
----
-
-<!-- DOCKER -->
-## Docker
-
-Install [Docker](https://docs.docker.com/get-docker/) and [docker-compose](https://docs.docker.com/compose/install/).
-
-See the `.env` file to configure per your needs. At minimum, you need to set `WEBSOCKET_HOST`.
-`WEBRTC_SERVER_URL` must point at your Lightspeed WebRTC server (defaults to
-`http://localhost:8080`) so the ingest service can allocate ports for each
-stream. `AUTH_WS_URL` should be the websocket address of the authentication
-service that validates stream keys. The stream key will be generated
-automatically on boot, and change each restart, unless you set a static one.
-
-### Development
-
-Use `docker-compose up` to start all containers at once and monitor the logs. When you are happy it is working you can 
-move to running detached.
-
-### Run Detached (background)
-
-Use `docker-compose up -d` to start all containers detached to have them run in the background. 
-
-Use `docker ps` to verify uptime, port forwarding, etc. 
-
-You can also use `docker-compose logs -f` to follow the logs of all the containers, and press `CTRL` + `C` to stop 
-following but leave the containers running.
-
-### Build Images manually
-
-For development purposes you can choose to build the containers locally instead of Docker Hub. Uncomment the `build:` and `context:` directives
-in the docker-compose.yml
-
-```
-git clone https://github.com/acarlton5/ITGv2
----
-./ITGv2  # Monorepo Root
-   frontend/
-   ingest/
-   webrtc/
-```
-
-Run `docker-compose build` to build the local container images. If you change the source code you will need to run again.
-You can run rebuild an individual container via `docker-compose build lightspeed-webrtc`.
 
 ---
 
@@ -281,7 +224,7 @@ your `services.json` file. It can be found at:
 - Windows: `%AppData%\obs-studio\plugin_config\rtmp-services\services.json` 
 - OSX: `/Users/YOURUSERNAME/Library/Application\ Support/obs-studio/plugin_config/rtmp-services/services.json`
 
-**Note**: Not all versions of Linux have access to OBS with the FTL SDK built in. If you are on Linux and you cannot stream to Lightspeed this may be the issue.
+**Note**: Not all versions of Linux have access to OBS with the FTL SDK built in. If you are on Linux and you cannot stream to Lightspeed this may be the issue
 
 Paste the below into the services array and change the url to either the IP or the hostname of your Project Lightspeed server
 
@@ -307,9 +250,9 @@ Paste the below into the services array and change the url to either the IP or t
 },
 ```
 
-NOTE: You do not need to specify a port.
+NOTE: You do not need to specify a port
 
-After restarting OBS you should be able to see your service in the OBS settings Stream pane.
+After restarting OBS you should be able to see your service in the OBS settings Stream pane
 (Special Thanks to [Glimesh](https://github.com/Glimesh) for these instructions)
 
 ---
@@ -318,22 +261,22 @@ After restarting OBS you should be able to see your service in the OBS settings 
 
 We are no longer using a default streamkey! If you are still using one please pull from master on the Lightspeed-ingest 
 repository. Now, by default on first time startup a new streamkey will be generated and output to the terminal for you. 
-In order to regenerate this key simply delete the file it generates called `hash`. In a Docker context we will work to 
-make the key reset process as easy as possible. Simply copy the key output in the terminal to OBS and you are all set! 
-This key WILL NOT change unless the `hash` file is deleted.
+In order to regenerate this key simply delete the file it generates called `hash`. 
+Simply copy the key output in the terminal to OBS and you are all set! 
+This key WILL NOT change unless the `hash` file is deleted
 
 <img src="images/streamkey-example.png" alt="Streamkey example">
 
 ### Multi-User Streaming
 
-When a streamer connects, the ingest service requests a dedicated UDP port from the WebRTC server using `WEBRTC_SERVER_URL`. That port hosts the stream until it ends, after which it is freed automatically. Each start and stop event is also sent to your auth service via `AUTH_WS_URL` so stream keys can be validated and tracked. Viewers connect to `/websocket?port=<allocated port>` to watch a specific stream.
+When a streamer connects, the ingest service requests a dedicated UDP port from the WebRTC server using `WEBRTC_SERVER_URL`. That port hosts the stream until it ends, after which it is freed automatically. Each start and stop event is also sent to your auth service via `AUTH_WS_URL` so stream keys can be validated and tracked. Viewers connect to `/websocket?port=<allocated port>` to watch a specific stream
 
 <!-- ROADMAP -->
 
 ## Bugs
 
 I am very from perfect and there are bound to be bugs and things I've overlooked in the installation process. 
-Please, add issues and feel free to reach out if anything is unclear. Also, we have a Discord.
+Please, add issues and feel free to reach out if anything is unclear. Also, we have a Discord
 
 <!-- CONTRIBUTING -->
 
@@ -352,7 +295,7 @@ Any contributions you make are **greatly appreciated**.
 
 ## License
 
-Distributed under the MIT License. See `LICENSE` for more information.
+Distributed under the MIT License. See `LICENSE` for more information
 
 <!-- CONTACT -->
 


### PR DESCRIPTION
## Summary
- update installation docs to match manual build approach
- remove Docker-based instructions and sample `.env`

## Testing
- `cargo test --quiet`
- `CI=true npm test --silent`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_687d6ef71ff883249520b647043a3ddb