### PR TITLE
Update React build docs for OpenSSL workaround

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,8 @@ You can host the static site locally using `serve` which can be found [here](htt
 ```sh
 cd frontend
 npm install
+# If the build fails with an OpenSSL error (common on Node 17+)
+export NODE_OPTIONS=--openssl-legacy-provider
 npm run build
 serve -s build -l 80
 ```

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -124,6 +124,8 @@ First build the frontend
 
 ```sh
 cd ITG-react
+# If the build fails with an OpenSSL error (common on Node 17+)
+export NODE_OPTIONS=--openssl-legacy-provider
 npm run build
 ```
 


### PR DESCRIPTION
## Summary
- document NODE_OPTIONS workaround for React build in both READMEs

## Testing
- `cargo build`
- `cargo test -- --test-threads=1`
- `go build ./...`
- `go test ./...`
- `CI=true npm test --silent`
- `NODE_OPTIONS=--openssl-legacy-provider npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687e4b925650832492b999ec9bd4ff6e