### PR TITLE
docs: add platform overview with quest framing

### DIFF
--- a/docs/document4_platform_overview.md
+++ b/docs/document4_platform_overview.md
@@ -1,0 +1,121 @@
+## 🧱 Platform Overview: Channels, Streams, Quests, and Relays
+
+### 1. What Is NOIZ as a Platform?
+
+**NOIZ** is a creator-first live streaming ecosystem that reimagines how digital support and infrastructure work together.
+
+Unlike traditional platforms that prioritize monetization through fiat currency or advertising, NOIZ centers its economy around **Decibels** — a virtual support token system. This framing allows NOIZ to foster community-driven growth, non-exploitative monetization, and meaningful interaction across the platform.
+
+Rather than relying on centralized server farms, NOIZ is powered by a decentralized relay infrastructure, hosted by users who contribute bandwidth and routing (Pathweavers). The entire system is designed to be lightweight, scalable, and fair — without relying on crypto, ads, or pay-to-win mechanics.
+
+---
+
+### 2. Channels: Your Creator Hub
+
+Each verified user on NOIZ has a **channel** — their home base for broadcasting, engaging with viewers, and customizing their community experience.
+
+A NOIZ channel includes:
+
+* Your live video stream (with viewer-adjustable quality and latency settings)
+* A custom channel banner, bio, and linked socials
+* A fully-featured chat system with moderation controls and plugin-based bot support
+* The ability to set up **Reverb** (channel points), visual badges, and engage with platform-wide **Quests**
+* Channel-specific boosts, overlays, and command shortcuts
+
+Viewers passively earn **Reverb** just by being present and interacting, which can then be spent on channel-specific redemptions, visual effects, or boosts.
+
+Channels evolve automatically as creators grow — new tools and cosmetic unlocks are added through milestone progression.
+
+---
+
+### 3. Streams: How Broadcasting Works on NOIZ
+
+NOIZ supports streaming via two main methods:
+
+* **NOIZ Studio**, a customized fork of OBS built for native integration
+* **Standard OBS**, modified to work with NOIZ’s ITGl routing protocol
+
+Low-latency streaming is enabled by default to allow real-time interaction. This is especially important for features like **Quests**, **Boosts**, and **Vibe-based interactions**.
+
+Additional stream capabilities include:
+
+* Embedded streams on external websites
+* Boosted visibility through Reverb or Decibel contributions
+* Raiding into other creators' channels
+* Eligibility for **Echostage**, NOIZ’s dynamic spotlight system
+
+Unlike other platforms with fixed bitrate tiers, NOIZ adapts quality based on viewer demand and infrastructure — creators are never penalized for having fewer viewers.
+
+---
+
+### 4. Quests: Sponsored Viewer Engagement
+
+**Quests** are platform-issued engagement campaigns — designed by **NOIZ, verified game publishers, or official sponsors** — to reward participation and support from viewers across the platform.
+
+These **goal-driven activities** are not created by individual creators but are offered through opt-in eligibility based on channel rating, game tag, or event participation.
+
+Viewers complete quests by performing verified actions such as:
+
+* Watching a stream for a specific duration
+* Sending chat messages
+* Triggering boosts or overlays
+* Gifting subs or completing event interactions
+
+On completion, **viewers may receive**:
+
+* dB (faded Decibels)
+* Cosmetic badges, stickers, or overlays
+* Progress toward milestone badges or viewer levels
+
+All quest mechanics are **action-based and non-purchasable** — meaning no skipping, no pay-to-win, and no off-platform engagement. Participation is rewarded purely through meaningful involvement.
+
+Some quests may also reward creators indirectly (⚡︎dB earned if a viewer completes a quest on their channel), but creators do not administer or customize these quests directly.
+
+---
+
+### 5. Relays: The Backbone of NOIZ Infrastructure
+
+Unlike traditional centralized streaming platforms, NOIZ runs on a distributed relay network powered by trusted members of the community — called **Pathweavers**.
+
+**Relays** are:
+
+* Lightweight nodes that forward video data to viewers
+* Selected automatically based on latency, trust score, and uptime
+* Not responsible for moderation or content — only transmission
+
+Relay operators may earn **⚡︎dB (charged Decibels)** as a reward for hosting reliable bandwidth and contributing to stream delivery. This is framed strictly as **support-based recognition**, not mining or payment.
+
+NOIZ’s system monitors each relay’s performance with internal checks, including:
+
+* Packet delivery integrity
+* Latency variability
+* Load balancing efficiency
+
+There are no tokens to mine, no external chains, and no speculative value — relays are rewarded through internal systems to maintain a stable, fair network.
+
+---
+
+### 6. How Everything Connects
+
+NOIZ’s streaming ecosystem is tightly interwoven:
+
+* **Channels** house the content and creator identity
+* **Streams** deliver that content through optimized, low-latency infrastructure
+* **Quests** turn passive viewers into active participants by offering incentives for engagement
+* **Relays** carry the stream to viewers around the world, powered by community bandwidth
+
+All of this is sustained by **Decibels**, which exist in two forms:
+
+| Type | Earned How                     | Cashout Eligible?               |
+| ---- | ------------------------------ | ------------------------------- |
+| dB   | Purchased via Constellation    | ❌ No                            |
+| ⚡︎dB | Earned through support actions | ✅ Yes (with legal verification) |
+
+This system ensures that:
+
+* Viewers can support creators using virtual tokens
+* Creators can earn ⚡︎dB based on real platform activity
+* Infrastructure hosts (Pathweavers) are recognized for helping power the platform
+* No one “pays” or “purchases” services — everything remains within the digital ecosystem
+
+---


### PR DESCRIPTION
## Summary
- add Document 4 with platform overview of NOIZ's channels, streams, quests, and relays

## Testing
- `cargo test`
- `go test ./...`
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_689110b52f348324b20a079f63c40de8